### PR TITLE
Added being able to tell the edlib aligner to respect ambiguous nucleotide codes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,4 +48,4 @@ setup(name='sars2seq',
       long_description=(
           'See https://github.com/virologycharite/sars2seq for details.'),
       license='MIT',
-      install_requires=['dark-matter>=4.0.19'])
+      install_requires=['dark-matter>=4.0.21'])


### PR DESCRIPTION
Needs dark-matter 4.0.21