### PR TITLE
Updated README docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,18 +55,18 @@ Features for NC_045512.2:
   stop: 21552
   length: 894
   product: 2'-O-ribose methyltransferase
-  sequence    (len   894 nt): TCTAGTCAAGCGTGGCAACCGGGTGTTGCTATGCCTAATCTTTACAAAATGCAAAGAATGCTATTAGAAAAGTGTGACCT...
+  sequence    (len   894 nt): TCTAGTCAAGCGTGGCAACCGGGTGTTGCTATGCCTAATCTTTACAAAA...
 3'-to-5' exonuclease:
   start: 18039
   stop: 19620
   length: 1581
   product: 3'-to-5' exonuclease
-  sequence    (len  1581 nt): GCTGAAAATGTAACAGGACTCTTTAAAGATTGTAGTAAGGTAATCACTGGGTTACATCCTACACAGGCACCTACACACCT...
+  sequence    (len  1581 nt): GCTGAAAATGTAACAGGACTCTTTAAAGATTGTAGTAAGGTAATCACTG...
 3'UTR:
   start: 29674
   stop: 29903
   length: 229
-  sequence    (len   229 nt): CAATCTTTAATCAGTGTGTAACATTAGGGAGGACTTGAAAGAGCCACCACATTTTCACCGAGGCCACGCGGAGTACGATC...
+  sequence    (len   229 nt): CAATCTTTAATCAGTGTGTAACATTAGGGAGGACTTGAAAGAGCCACCA...
 # [Many additional output lines omitted here.]
 ```
 
@@ -79,8 +79,8 @@ surface glycoprotein:
   stop: 25384
   length: 3822
   product: surface glycoprotein
-  sequence    (len  3822 nt): ATGTTTGTTTTTCTTGTTTTATTGCCACTAGTCTCTAGTCAGTGTGTTAATCTTACAACCAGAACTCAATTACCCCCTGC...
-  translation (len  1274 aa): MFVFLVLLPLVSSQCVNLTTRTQLPPAYTNSFTRGVYYPDKVFRSSVLHSTQDLFLPFFSNVTWFHAIHVSGTNGTKRFD...
+  sequence    (len  3822 nt): ATGTTTGTTTTTCTTGTTTTATTGCCACTAGTCTCTAGTCAGTGTGTTA...
+  translation (len  1274 aa): MFVFLVLLPLVSSQCVNLTTRTQLPPAYTNSFTRGVYYPDKVFRSSVLH...
 ```
 
 Or ask to see all known feature names. Each is printed followed by a colon
@@ -129,8 +129,8 @@ surface glycoprotein: s, spike
 
 `describe-genome.py` has many uses. It can extract multiple features from
 multiple given genomes, as amino acids or nucleotides (or both). It will
-print to standard error by default, but if you use the `--outDir` option to
-provide a directory, individual output files with (hopefully)
+print to standard output by default, but if you use the `--outDir` option
+to provide a directory, individual output files with (hopefully)
 self-explanatory names will be created in that directory. The directory
 will be created for you if it doesn't exist.
 
@@ -299,7 +299,8 @@ $ describe-site.py --site 501 --feature spike --relative --aa
 }
 ```
 
-Of course it's more fun if you also provide a genome to compare the reference to:
+Of course it's more fun if you also provide a genome to compare the reference to.
+Here's the `N501Y` change in B.1.1.7 (Alpha):
 
 ```sh
 $ describe-site.py --site 501 --relative --genome EPI_ISL_601443.fasta --feature spike --aa
@@ -331,7 +332,7 @@ $ describe-site.py --site 501 --relative --genome EPI_ISL_601443.fasta --feature
 Other options include `--genomeAaOnly` to just print the amino acid at a
 location in the genome, `--includeFeature` to also receive information
 about the feature at the site, and `--minReferenceCoverage` to exclude
-low-coverage genomes from the results.
+low-coverage genomes or features from the results.
 
 ## Python API
 
@@ -350,7 +351,7 @@ download the GenBank file for that reference, click on "Send to" and select
 
 You can pass the path to a GenBank file to the `Features` class. You can
 also just pass an accession number, and the file will be downloaded for
-yo. If you don't pass anything, the Wuhan reference (version `NC_045512.2`)
+you. If you don't pass anything, the Wuhan reference (version `NC_045512.2`)
 will be used.
 
 You can use a `Features` instance like a dictionary:
@@ -359,6 +360,7 @@ You can use a `Features` instance like a dictionary:
 from pprint import pprint
 from sars2seq.features import Features
 
+>>> f = Features()
 >>> pprint(f['e'])
 {'name': 'envelope protein',
  'note': 'ORF4; structural protein; E protein',
@@ -505,6 +507,9 @@ as expected (`True`), the value in the genome (`Y`).
 You can test multiple things:
 
 ``` py
+# Note that we use 501Y in the following, not N501Y, since we might just
+# want to check that something is in the genome without knowing or caring
+# about what's in the reference.
 >>> pp(genome.checkFeature('spike', '501Y 69- 70-', aa=True))
 (3,
  0,
@@ -516,7 +521,6 @@ You can test multiple things:
 
 There is also a convenience `Checker` class that can check whether logical
 combinations of amino acid and nucleotide changes are satisfied for a genome.
-
 Continuing from the above:
 
 ``` py
@@ -531,7 +535,7 @@ True
 # Check for some nucleotide changes in the nucleocapsid and some amino
 # acid changes in the spike.
 checker = (NTChecker('N', 'G7C A8T T9A G608A G609A G610C C704T') &
-           AAChecker('spike', 'N501Y H69- V70- Y144-'))
+           AAChecker('S', 'N501Y H69- V70- Y144-'))
 
 # You can also use `|` to check an OR condition.
 >>> checker = AAChecker('spike', 'E484K') | AAChecker('spike', 'E484Q')
@@ -582,16 +586,19 @@ You can pass your own variant dictionary specifying what you want checked.
 See the `Features` and `SARS2Genome` classes in
 [sars2seq/feature.py](sars2seq/genome.py) and
 [sars2seq/genome.py](sars2seq/genome.py). Also, the tests (e.g., in
-[test/test_genome.py], [test/test_checker.py] [test/test_variants.py]) show
-you example uses of these classes and their methods.  You can also look to
-see how the three utility scripts described above (which can all be found
-in the [bin directory](bin)) call the library functions and use the
-results.
+[test/test_genome.py](test/test_genome.py),
+[test/test_checker.py](test/test_checker.py)
+[test/test_variants.py](test/test_variants.py)) show you example uses of
+these classes and their methods.  You can also look to see how the three
+utility scripts described above (which can all be found in the [bin
+directory](bin)) call the library functions and use the results.
 
 ## Developing
 
 Run the tests via 
 
 ```sh
-$ make pytest`
+$ pytest`
 ```
+
+More could probably be added here :-)

--- a/bin/describe-feature.py
+++ b/bin/describe-feature.py
@@ -100,7 +100,7 @@ if __name__ == '__main__':
 
     parser.add_argument(
         '--gbFile', metavar='file.gb', default=Features.REF_GB,
-        help='The Genbank file to examine.')
+        help='The GenBank file to examine.')
 
     parser.add_argument(
         '--name', metavar='NAME',

--- a/bin/describe-genome.py
+++ b/bin/describe-genome.py
@@ -372,7 +372,7 @@ if __name__ == '__main__':
 
     parser.add_argument(
         '--gbFile', metavar='file.gb', default=Features.REF_GB,
-        help='The Genbank file to read for SARS-CoV-2 features.')
+        help='The GenBank file to read for SARS-CoV-2 features.')
 
     parser.add_argument(
         '--minReferenceCoverage', metavar='coverage', type=float,

--- a/bin/describe-site.py
+++ b/bin/describe-site.py
@@ -154,7 +154,7 @@ if __name__ == '__main__':
 
     parser.add_argument(
         '--gbFile', metavar='file.gb', default=Features.REF_GB,
-        help='The Genbank file to read for SARS-CoV-2 features.')
+        help='The GenBank file to read for SARS-CoV-2 features.')
 
     addAlignerOption(parser)
 

--- a/bin/victor-summary.py
+++ b/bin/victor-summary.py
@@ -433,7 +433,7 @@ if __name__ == '__main__':
 
     parser.add_argument(
         '--gbFile', metavar='file.gb', default=Features.REF_GB,
-        help='The Genbank file to read for SARS-CoV-2 features.')
+        help='The GenBank file to read for SARS-CoV-2 features.')
 
     addAlignerOption(parser)
 

--- a/sars2seq/__init__.py
+++ b/sars2seq/__init__.py
@@ -1,10 +1,10 @@
 from pathlib import Path
 
-__version__ = '0.0.7'
-
 
 class Sars2SeqError(Exception):
-    'A sars2seq library error'
+    'A sars2seq library error occurred'
 
+
+__version__ = '0.1.0'
 
 DATA_DIR = Path(__file__).parent.parent / 'data'

--- a/sars2seq/checker.py
+++ b/sars2seq/checker.py
@@ -2,25 +2,25 @@ import copy
 
 
 class Checker:
-    def __init__(self, featureName, changes, nt):
+    def __init__(self, featureName, changes, aa=False):
         """
         Check genome changes occurred.
 
         @param featureName: The C{str} name of the feature to check (e.g.,
             'nsp2').
         @param changes: A C{str} specification in the form of space-separated
-            RNS strings, where R is a reference base, N is an integer offset,
+            RNS strings, where R is a reference base, N is an integer site,
             and S is a sequence base. So, e.g., 'L28S P1003Q' indicates that
-            we expected a change from 'L' to 'S' at offset 28 and from 'P' to
-            'Q' at offset 1003.
-        @param nt: If C{True} check nucleotide sequences. Else protein.
+            we expected a change from 'L' to 'S' at site 28 and from 'P' to
+            'Q' at site 1003.
+        @param aa: If C{True} check amino acid sequences. Else nucleotide.
         """
         self.description = (
-            f'Check {featureName!r} for {"nt" if nt else "aa"} '
+            f'Check {featureName!r} for {"aa" if aa else "nt"} '
             f'changes {changes!r}')
 
         def check(genome):
-            _, errorCount, _ = genome.checkFeature(featureName, changes, nt)
+            _, errorCount, _ = genome.checkFeature(featureName, changes, aa)
             return errorCount == 0
 
         self._func = check
@@ -55,9 +55,9 @@ class Checker:
 
 class AAChecker(Checker):
     def __init__(self, featureName, changes):
-        super().__init__(featureName, changes, False)
+        super().__init__(featureName, changes, True)
 
 
 class NTChecker(Checker):
     def __init__(self, featureName, changes):
-        super().__init__(featureName, changes, True)
+        super().__init__(featureName, changes, False)

--- a/sars2seq/features.py
+++ b/sars2seq/features.py
@@ -123,8 +123,8 @@ class Features(UserDict):
     Manage sequence features from the information in C{gbFile}.
 
     @param spec: Either:
-        * A C{str} name or C{Path} of a Genbank file containing the features.
-        * A C{str} Genbank accession id.
+        * A C{str} name or C{Path} of a GenBank file containing the features.
+        * A C{str} GenBank accession id.
         * A C{dict} of pre-prepared features, in which case C{reference}
               must not be C{None}. Passing a C{dict} is provided for testing.
         * C{None}, in which case the default reference, NC_045512.2.gb, is
@@ -151,7 +151,7 @@ class Features(UserDict):
                 with open(path) as fp:
                     record = SeqIO.read(fp, 'genbank')
             else:
-                print(f'Fetching Genbank record for {spec!r}.',
+                print(f'Fetching GenBank record for {spec!r}.',
                       file=sys.stderr)
                 client = Entrez.efetch(db='nucleotide', rettype='gb',
                                        retmode='text', id=spec)
@@ -246,9 +246,9 @@ class Features(UserDict):
 
             {
                 'function': A string description of the feature's function,
-                    if one was present in the Genbank file.
+                    if one was present in the GenBank file.
                 'product': A string description of the product of the feature.
-                    if one was present in the Genbank file.
+                    if one was present in the GenBank file.
                 'name': The string name.
                 'note': A string note, if one was is present in the GenBank
                     file.

--- a/sars2seq/features.py
+++ b/sars2seq/features.py
@@ -131,6 +131,8 @@ class Features(UserDict):
               loaded.
     @param reference: A C{dark.reads.DNARead} instance if C{spec} is a C{dict},
         else C{None}.
+    @raise ValueError: If a reference is passed with a string or Path
+        specification.
     @raise ReferenceWithGapError: If the reference or one of its features has a
         gap in its nucleotide sequence.
     """
@@ -141,7 +143,9 @@ class Features(UserDict):
         spec = self.REF_GB if spec is None else spec
 
         if isinstance(spec, str):
-            assert reference is None
+            if reference is not None:
+                raise ValueError('A reference cannot be passed with a string '
+                                 'specification.')
             path = Path(spec)
             if path.exists():
                 with open(path) as fp:
@@ -155,7 +159,9 @@ class Features(UserDict):
                 client.close()
             self._initializeFromGenBankRecord(record)
         elif isinstance(spec, Path):
-            assert reference is None
+            if reference is not None:
+                raise ValueError('A reference cannot be passed with a Path '
+                                 'specification.')
             with open(spec) as fp:
                 record = SeqIO.read(fp, 'genbank')
             self._initializeFromGenBankRecord(record)
@@ -170,6 +176,8 @@ class Features(UserDict):
         Initialize from a GenBank record.
 
         @param record: A BioPython C{SeqRecord} sequence record.
+        @raise ReferenceWithGapError: If the reference sequence or the
+            sequence of any of its features has a gap.
         """
         self.reference = DNARead(record.id, str(record.seq))
 
@@ -231,6 +239,40 @@ class Features(UserDict):
 
         self._checkForGaps()
 
+    def __getitem__(self, name):
+        """
+        Find a feature by name. This produces a dictionary with the following
+        keys and values for the feature:
+
+            {
+                'function': A string description of the feature's function,
+                    if one was present in the Genbank file.
+                'product': A string description of the product of the feature.
+                    if one was present in the Genbank file.
+                'name': The string name.
+                'note': A string note, if one was is present in the GenBank
+                    file.
+                'sequence': The string nucleotide sequence.
+                'start': A 0-based integer offset of the first nucleotide of
+                    the feature in the complete genome.
+                'stop': A 0-based integer offset of the nucleotide after the
+                    last nucleotide in the feature in the complete genome.
+                    Thus start and stop can be used in the regular Python
+                    way of slicing out substrings.
+                'translation': The amino acid translation of the feature, if
+                    one is provided by the GenBank record. Note that
+                    translations may not be provided for all features! If you
+                    need to know what is actually translated, use the
+                    TRANSLATED set defined at the top of this file.
+            }
+
+
+        @param name: A C{str} feature name to look up.
+        @raise KeyError: If the name is unknown.
+        @return: A C{dict} for the feature, as above.
+        """
+        return self.data[self.canonicalName(name)]
+
     def canonicalName(self, name):
         """
         Get the canonical name for a feature.
@@ -245,42 +287,34 @@ class Features(UserDict):
         nameLower = name.lower()
         for featureName in self:
             if nameLower == featureName.lower():
-                return nameLower
+                return featureName
 
         alias = ALIASES.get(nameLower)
-        if alias:
+        if alias is None:
+            raise KeyError(name)
+        else:
             assert alias in self
             return alias
 
-        raise KeyError(name)
-
-    def __getitem__(self, name):
+    def aliases(self, name):
         """
-        Find a feature by name.
+        Get all aliases for a name.
 
-        @param name: A C{str} feature name to look up.
-        @return: A C{dict} for the feature.
+        @param name: A C{str} feature name.
+        @return: A C{set} of C{str} canonical names.
         """
-        try:
-            return self.data[name]
-        except KeyError:
-            nameLower = name.lower()
-            for featureName in self.data:
-                if nameLower == featureName.lower():
-                    name = featureName
-                    break
-            else:
-                alt = ALIASES.get(nameLower)
-                if alt is None:
-                    raise KeyError(name)
-                else:
-                    name = alt
+        canonicalName = self.canonicalName(name)
+        result = {canonicalName}
 
-        return self.data[name]
+        for alias, canonical in ALIASES.items():
+            if canonical == canonicalName:
+                result.add(alias)
+
+        return result
 
     def _checkForGaps(self):
         """
-        Check there are no gaps in the reference or and feature sequence.
+        Check there are no gaps in the reference or any feature sequence.
 
         @raise ReferenceWithGapError: If the reference sequence or the
             sequence of any of its features has a gap.
@@ -310,9 +344,9 @@ class Features(UserDict):
         """
         return self[name]['start'] + offset * (3 if aa else 1)
 
-    def featuresAt(self, offset, includeUntranslated=False):
+    def getFeatureNames(self, offset, includeUntranslated=False):
         """
-        Get the names of features that overlap a given offset.
+        Get the names of all features that overlap a given offset.
 
         @param offset: An C{int} offset into the genome.
         @param includeUntranslated: If C{True}, also return features that are
@@ -330,27 +364,29 @@ class Features(UserDict):
 
     def getFeature(self, offset, featureName=None, includeUntranslated=False):
         """
-        Find a feature by name or raise an error.
+        Find a single feature at an offset.
 
-        @param offset: The C{int} offset that was used to find C{features}.
-        @param featureName: A C{str} feature name. If C{None}, a feature will
-            be returned if there is only one at the offset.
-        @param includeUntranslated: If C{True}, also return features that are
+        @param offset: An C{int} offset into the genome.
+        @param featureName: A C{str} feature name. Used for disambiguation when
+            multiple features are present at the offset. If C{None}, a feature
+            will be returned if there is only one at the given offset.
+        @param includeUntranslated: If C{True}, also consider features that are
             not translated.
         @raise MissingFeatureError: if the requested feature does not overlap
             the given C{offset} or if there are no features at the offset.
         @raise AmbiguousFeatureError: if there are multiple features at the
             offset and a feature name is not given.
-        @return: A 2-tuple, containing 1) a features C{dict}, if the requested
-            feature is present in the features at the offset, and 2) the set of
-            C{str} feature names present at the offset.
+        @return: A 2-tuple, containing 1) a features C{dict} (as returned by
+            __getitem__), if the requested feature is among those present at
+            the offset, and 2) the set of all C{str} feature names present at
+            the offset.
         """
-        features = self.featuresAt(offset, includeUntranslated)
+        features = self.getFeatureNames(offset, includeUntranslated)
 
         if featureName is None:
             if features:
-                # There are some features here, but we weren't told which
-                # one to use. Only proceed if there's just one.
+                # There are some features here, but we weren't told which one
+                # to use. Only proceed if there's just one.
                 if len(features) == 1:
                     featureName = list(features)[0]
                     feature = self[featureName]

--- a/test/test_checker.py
+++ b/test/test_checker.py
@@ -25,7 +25,7 @@ class Test_EPI_ISL_601443(TestCase):
         If an check on a non-existent index is attempted, an IndexError must
         be raised.
         """
-        checker = Checker('spike', 'N500001Y', False)
+        checker = Checker('spike', 'N500001Y', aa=True)
         error = (r"^Index 500000 out of range trying to access feature "
                  r"'spike' of length 1274 sequence 'NC_045512.2 \(surface "
                  r"glycoprotein\)' via expected change specification "
@@ -36,15 +36,15 @@ class Test_EPI_ISL_601443(TestCase):
         """
         The variant has the N501Y change.
         """
-        checker = Checker('spike', 'N501Y', False)
+        checker = Checker('spike', 'N501Y', aa=True)
         self.assertTrue(checker(self.genome))
 
     def testN501YandA570D(self):
         """
         The variant has the A570D change. Check with the base Checker class.
         """
-        checker = (Checker('spike', 'N501Y', False) and
-                   Checker('spike', 'A570D', False))
+        checker = (Checker('spike', 'N501Y', aa=True) and
+                   Checker('spike', 'A570D', aa=True))
         self.assertTrue(checker(self.genome))
 
     def testN501YAA(self):

--- a/test/test_genomes.py
+++ b/test/test_genomes.py
@@ -24,7 +24,7 @@ class _Mixin:
     def testLength(self):
         self.assertGreater(len(self.genomeRead), 28000)
 
-    def check(self, featureName, changes, nt):
+    def check(self, featureName, changes, aa=False):
         """
         Check that a set of changes all happened as expected.
 
@@ -35,10 +35,10 @@ class _Mixin:
             and S is a sequence base. So, e.g., 'L28S P1003Q' indicates that
             we expected a change from 'L' to 'S' at offset 28 and from 'P' to
             'Q' at offset 1003.
-        @param nt: If C{True} check nucleotide sequences. Else protein.
+        @param aa: If C{True} check amino acid sequences. Else nucleotide.
         """
         _, errorCount, result = self.genome.checkFeature(
-            featureName, changes, nt)
+            featureName, changes, aa)
         if errorCount:
             for change, (referenceOK, _, genomeOK, _) in result.items():
                 if not referenceOK:
@@ -75,7 +75,7 @@ class Test_EPI_ISL_601443(TestCase, _Mixin):
         """
         The spike protein should have the three deletions.
         """
-        self.check('spike', 'H69- V70- Y144-', nt=False)
+        self.check('spike', 'H69- V70- Y144-', True)
 
     def testSpikeMutationsAa(self):
         """
@@ -84,7 +84,7 @@ class Test_EPI_ISL_601443(TestCase, _Mixin):
         don't say what reference their SNPs are relative to)
         """
         self.check('spike', 'N501Y A570D D614G P681H T716I S982A D1118H',
-                   False)
+                   True)
 
     def testSpikeDeletionVariant(self):
         """
@@ -148,13 +148,13 @@ class Test_EPI_ISL_601443(TestCase, _Mixin):
         """
         The ORF1a protein should have the expected deletions.
         """
-        self.check('orf1a', 'S3675- G3676- F3677-', False)
+        self.check('orf1a', 'S3675- G3676- F3677-', True)
 
     def testORF1aMutationsAa(self):
         """
         The ORF1a protein should have the expected amino acid changes.
         """
-        self.check('orf1a', 'T1001I A1708D I2230T', False)
+        self.check('orf1a', 'T1001I A1708D I2230T', True)
 
     def testORF1abTranslationBug(self):
         """
@@ -170,13 +170,13 @@ class Test_EPI_ISL_601443(TestCase, _Mixin):
         """
         The ORF1ab protein should have the expected deletions.
         """
-        self.check('orf1ab', 'S3675- G3676- F3677-', False)
+        self.check('orf1ab', 'S3675- G3676- F3677-', True)
 
     def testORF1abMutationsAa(self):
         """
         The ORF1ab protein should have the expected amino acid changes.
         """
-        self.check('orf1ab', 'T1001I A1708D I2230T', False)
+        self.check('orf1ab', 'T1001I A1708D I2230T', True)
 
     def testNucleocapsidMutationsNt(self):
         """
@@ -186,20 +186,20 @@ class Test_EPI_ISL_601443(TestCase, _Mixin):
         # location 235. That's a 0-based offset of 234 = 702 in the
         # genome. The change is an S -> via a TCT -> TTT mutation in the
         # middle position, or 703 in 0-based, and 704 in 1-based.
-        self.check('N', 'G7C A8T T9A G608A G609A G610C C704T', True)
+        self.check('N', 'G7C A8T T9A G608A G609A G610C C704T', False)
 
     def testNucleocapsidMutationsAa(self):
         """
         The nucleocapsid protein should have the expected amino acid changes.
         Note that the UK report does not include mention of R203K or G204R.
         """
-        self.check('N', 'D3L R203K G204R S235F', False)
+        self.check('N', 'D3L R203K G204R S235F', True)
 
     def testORF8MutationsAa(self):
         """
         The ORF8 protein should have the expected amino acid changes.
         """
-        self.check('orf8', 'Q27* R52I Y73C', False)
+        self.check('orf8', 'Q27* R52I Y73C', True)
 
     def testSNPs(self):
         """
@@ -232,19 +232,19 @@ class Test_BavPat2(TestCase, _Mixin):
         """
         The spike genome should have the expected change.
         """
-        self.check('spike', 'A1841G', True)
+        self.check('spike', 'A1841G', False)
 
     def testSpikeMutationsAa(self):
         """
         The spike protein should have the expected amino acid change.
         """
-        self.check('spike', 'D614G', False)
+        self.check('spike', 'D614G', True)
 
     def testORF1aMutationsNt(self):
         """
         The ORF1a genome should have the expected change.
         """
-        self.check('orf1a', 'C2772T', True)
+        self.check('orf1a', 'C2772T', False)
 
     def testSpikeDeletionVariant(self):
         """
@@ -423,14 +423,14 @@ class Test_EPI_ISL_678597(TestCase, _Mixin):
         """
         The spike protein should have the three deletions.
         """
-        self.check('spike', 'L241- L242- A243-', nt=False)
+        self.check('spike', 'L241- L242- A243-', True)
 
     def testSpikeMutationsAa(self):
         """
         The spike protein should have the expected amino acid changes.
         """
         self.check('spike', 'D80A D215G K417N E484K N501Y D614G A701V',
-                   False)
+                   True)
 
     def testSpikeDeletionVariant(self):
         """
@@ -473,35 +473,35 @@ class Test_EPI_ISL_678597(TestCase, _Mixin):
         testCount, errorCount, _ = self.genome.checkVariant('VOC_20201201_UK')
         self.assertEqual(20, testCount)
         self.assertEqual(16, errorCount)
-        self.check('spike', 'N501Y', False)
-        self.check('orf1ab', 'S3675- G3676- F3677-', False)
+        self.check('spike', 'N501Y', True)
+        self.check('orf1ab', 'S3675- G3676- F3677-', True)
 
     def testORF1aDeletionsAa(self):
         """
         The ORF1a protein should have the expected deletions.
         """
-        self.check('orf1a', 'S3675- G3676- F3677-', False)
+        self.check('orf1a', 'S3675- G3676- F3677-', True)
 
     def testORF1aMutationsAa(self):
         """
         The ORF1a protein should have the expected amino acid changes.
         """
-        self.check('orf1a', 'T265I K1655N K3353R', False)
+        self.check('orf1a', 'T265I K1655N K3353R', True)
 
     def testNucleocapsidMutationsNt(self):
         """
         The nucleocapsid genome should have the expected changes.
         """
-        self.check('N', 'C614T', True)
+        self.check('N', 'C614T', False)
 
     def testNucleocapsidMutationsAa(self):
         """
         The nucleocapsid protein should have the expected amino acid changes.
         """
-        self.check('N', 'T205I', False)
+        self.check('N', 'T205I', True)
 
     def testORF3aMutationsAa(self):
         """
         The ORF3a protein should have the expected amino acid changes.
         """
-        self.check('orf3a', 'Q57H S171L', False)
+        self.check('orf3a', 'Q57H S171L', True)


### PR DESCRIPTION
There are two backwards-incompatible changes herein.

1. The `nt` argument to some checker functions has been renamed to `aa` so you now need to pass the opposite Boolean value.
2. The `featuresAt` method of the `Features` class has been renamed to `getFeatureNames`.

I have no idea if anyone is using this code apart from us, so I'm guessing these won't cause big problems.

I should be more formal about such things, and will be if there is a 1.0.0 release.