### PR TITLE
Generalize to no longer be SARS-CoV-2 specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ data/*.fai
 .DS_Store
 sars2seq.egg-info
 dist
+.coverage

--- a/bin/annotate-genome.py
+++ b/bin/annotate-genome.py
@@ -182,8 +182,8 @@ if __name__ == "__main__":
         "--reportDifferences",
         action="store_true",
         help=(
-            "If the genome ORF differs from the reference due to no start "
-            "or stop codon, print a message.",
+            "If the genome ORF differs from the reference due to no start or stop "
+            "codon, print a message."
         ),
     )
 

--- a/bin/annotate-genome.py
+++ b/bin/annotate-genome.py
@@ -11,7 +11,7 @@ from sars2seq.alignment import SARS2Alignment, addAlignerOption, alignmentEnd
 from sars2seq.features import Features, addFeatureOptions
 
 
-def main(args):
+def main(args: argparse.Namespace) -> int:
     """
     Add features to an unannotated genome and print the result as JSON.
 
@@ -145,7 +145,7 @@ def main(args):
             else:
                 lenDiff = f"{abs(n)} aa " + ("shorter" if n < 0 else "longer")
 
-            if aaDiff or lenDiff:
+            if not (aaDiff == lenDiff == "-"):
                 count += 1
                 print(
                     "\t".join(

--- a/bin/annotate-genome.py
+++ b/bin/annotate-genome.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+
+import sys
+import argparse
+from json import dumps
+from operator import itemgetter
+
+from dark.fasta import FastaReads
+
+from sars2seq.alignment import SARS2Alignment, addAlignerOption, alignmentEnd
+from sars2seq.features import Features, addFeatureOptions
+
+
+def main(args):
+    """
+    Add features to an unannotated genome and print the result as JSON.
+
+    @param args: A C{Namespace} instance as returned by argparse with
+        values for command-line options.
+    @return: An C{int} exit status.
+    """
+    features = Features(args.reference, sars2=args.sars2)
+    genome = list(FastaReads(args.genome))[0]
+    alignment = SARS2Alignment(genome, features, aligner=args.aligner)
+    key = itemgetter("start")
+    result = {
+        "id": genome.id,
+        "sequence": genome.sequence,
+        "features": {},
+    }
+
+    resultFeatures = result["features"]
+
+    for feature in sorted(features.values(), key=key):
+        name = feature["name"]
+        forward = feature["forward"]
+        gappedOffset = alignment.gappedOffsets[feature["start"]]
+
+        referenceAA, genomeAA = alignment.aaSequences(name, raiseOnReferenceGaps=False)
+
+        start = gappedOffset - alignment.genomeAligned.sequence[:gappedOffset].count(
+            "-"
+        )
+
+        if forward:
+            assert 0 <= start < len(genome)
+            orf = genome.findORF(start, forward=True, requireStartCodon=False)
+        else:
+            reverseGappedOffset = alignment.gappedOffsets[feature["stop"]]
+            reverseStart = (
+                len(alignment.genomeAligned)
+                - reverseGappedOffset
+                - alignment.genomeAligned.sequence[reverseGappedOffset:].count("-")
+            )
+            assert 0 <= reverseStart < len(genome)
+            orf = genome.findORF(reverseStart, forward=False, requireStartCodon=False)
+
+        # Small sanity check.
+        if not orf["foundStartCodon"]:
+            assert genomeAA.sequence[0] != "M"
+
+        stop = start + orf["length"] * 3
+
+        resultFeatures[name] = feature.copy()
+        resultFeatures[name].update(
+            {
+                "start": start,
+                "stop": stop,
+                "sequence": genome.sequence[start:stop],
+                "translation": orf["translation"],
+            }
+        )
+
+        aaDiffs = {}
+
+        if len(orf["translation"]) != len(referenceAA):
+            aaDiffs["lengths"] = {
+                "genome length": len(orf["translation"]),
+                "reference length": len(referenceAA),
+                "difference": len(orf["translation"]) - len(referenceAA),
+            }
+
+        subs = []
+        # Note the the following zip deliberately stops at the shortest AA
+        # sequence.
+        for site, (aa1, aa2) in enumerate(
+            zip(referenceAA.sequence, orf["translation"]), start=1
+        ):
+            if aa1 != aa2:
+                subs.append(f"{aa1}{site}{aa2}")
+
+        if subs:
+            aaDiffs["substitutions"] = subs
+
+        if aaDiffs:
+            resultFeatures[name]["aa differences"] = aaDiffs
+
+        if not (orf["foundStartCodon"] and orf["foundStopCodon"]):
+            aend = alignmentEnd(
+                alignment.referenceAligned.sequence,
+                gappedOffset,
+                feature["stop"] - feature["start"],
+            )
+            resultFeatures[name]["debug"] = {
+                "genome orf": orf,
+                "feature alignment": {
+                    "reference": alignment.referenceAligned.sequence[gappedOffset:aend],
+                    "genome": alignment.genomeAligned.sequence[gappedOffset:aend],
+                },
+                "reference feature": feature.copy(),
+            }
+
+        if args.reportDifferences:
+            if not orf["foundStartCodon"]:
+                print(
+                    f"No START codon found for genome feature " f"{feature['name']!r}.",
+                    file=sys.stderr,
+                )
+
+            if not orf["foundStopCodon"]:
+                print(
+                    f"No STOP  codon found for genome feature " f"{feature['name']!r}.",
+                    file=sys.stderr,
+                )
+
+    # Sanity check that the Features class can load what we just produced.
+    Features(result, sars2=args.sars2)
+    print(dumps(result, sort_keys=True, indent=4))
+
+    if args.summarize:
+        print(f'Summary of changes for {result["id"]!r}', file=sys.stderr)
+        count = 0
+        for name, info in result["features"].items():
+            try:
+                aaDiffs = info["aa differences"]["substitutions"]
+            except KeyError:
+                aaDiff = "-"
+            else:
+                aaDiff = ", ".join(aaDiffs)
+
+            try:
+                n = info["aa differences"]["lengths"]["difference"]
+            except KeyError:
+                lenDiff = "-"
+            else:
+                lenDiff = f"{abs(n)} aa " + ("shorter" if n < 0 else "longer")
+
+            if aaDiff or lenDiff:
+                count += 1
+                print(
+                    "\t".join(
+                        (str(count), name, aaDiff, lenDiff, info.get("note", ""))
+                    ),
+                    file=sys.stderr,
+                )
+
+    return 0
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description="Print JSON annotations for a genome (or genomes).",
+    )
+
+    parser.add_argument(
+        "--genome",
+        metavar="file.fasta",
+        type=argparse.FileType("r"),
+        default=sys.stdin,
+        help="The FASTA file containing the SARS-CoV-2 genome(s) to examine.",
+    )
+
+    parser.add_argument(
+        "--summarize",
+        action="store_true",
+        help="Write a summary of differences to standard error.",
+    )
+
+    parser.add_argument(
+        "--reportDifferences",
+        action="store_true",
+        help=(
+            "If the genome ORF differs from the reference due to no start "
+            "or stop codon, print a message.",
+        ),
+    )
+
+    addAlignerOption(parser)
+    addFeatureOptions(parser)
+
+    args = parser.parse_args()
+
+    sys.exit(main(args))

--- a/bin/annotate-genome.py
+++ b/bin/annotate-genome.py
@@ -3,162 +3,47 @@
 import sys
 import argparse
 from json import dumps
-from operator import itemgetter
 
 from dark.fasta import FastaReads
 
-from sars2seq.alignment import SARS2Alignment, addAlignerOption, alignmentEnd
+from sars2seq.alignment import addAlignerOption
+from sars2seq.annotate import annotateGenome, summarizeDifferences
 from sars2seq.features import Features, addFeatureOptions
 
 
 def main(args: argparse.Namespace) -> int:
     """
-    Add features to an unannotated genome and print the result as JSON.
+    Create, optionally summarize (to standard error), and print (as JSON, to
+    standard out) annotations for a genome.
 
-    @param args: A C{Namespace} instance as returned by argparse with
-        values for command-line options.
-    @return: An C{int} exit status.
+    @param args: An C{argparse.Namespace} instance with command-line values.
     """
     features = Features(args.reference, sars2=args.sars2)
     genome = list(FastaReads(args.genome))[0]
-    alignment = SARS2Alignment(genome, features, aligner=args.aligner)
-    key = itemgetter("start")
-    result = {
-        "id": genome.id,
-        "sequence": genome.sequence,
-        "features": {},
-    }
 
-    resultFeatures = result["features"]
-
-    for feature in sorted(features.values(), key=key):
-        name = feature["name"]
-        forward = feature["forward"]
-        gappedOffset = alignment.gappedOffsets[feature["start"]]
-
-        referenceAA, genomeAA = alignment.aaSequences(name, raiseOnReferenceGaps=False)
-
-        start = gappedOffset - alignment.genomeAligned.sequence[:gappedOffset].count(
-            "-"
+    try:
+        annotations = annotateGenome(features, genome, args.aligner)
+    except Exception as e:
+        print(
+            f"Failed to annotate {genome.id!r} from {args.reference!r}: {e}",
+            file=sys.stderr,
         )
+        return 1
+    else:
+        print(dumps(annotations, sort_keys=True, indent=4))
 
-        if forward:
-            assert 0 <= start < len(genome)
-            orf = genome.findORF(start, forward=True, requireStartCodon=False)
-        else:
-            reverseGappedOffset = alignment.gappedOffsets[feature["stop"]]
-            reverseStart = (
-                len(alignment.genomeAligned)
-                - reverseGappedOffset
-                - alignment.genomeAligned.sequence[reverseGappedOffset:].count("-")
-            )
-            assert 0 <= reverseStart < len(genome)
-            orf = genome.findORF(reverseStart, forward=False, requireStartCodon=False)
+        if args.summarize:
+            print(summarizeDifferences(annotations), file=sys.stderr)
 
-        # Small sanity check.
-        if not orf["foundStartCodon"]:
-            assert genomeAA.sequence[0] != "M"
-
-        stop = start + orf["length"] * 3
-
-        resultFeatures[name] = feature.copy()
-        resultFeatures[name].update(
-            {
-                "start": start,
-                "stop": stop,
-                "sequence": genome.sequence[start:stop],
-                "translation": orf["translation"],
-            }
-        )
-
-        aaDiffs = {}
-
-        if len(orf["translation"]) != len(referenceAA):
-            aaDiffs["lengths"] = {
-                "genome length": len(orf["translation"]),
-                "reference length": len(referenceAA),
-                "difference": len(orf["translation"]) - len(referenceAA),
-            }
-
-        subs = []
-        # Note the the following zip deliberately stops at the shortest AA
-        # sequence.
-        for site, (aa1, aa2) in enumerate(
-            zip(referenceAA.sequence, orf["translation"]), start=1
-        ):
-            if aa1 != aa2:
-                subs.append(f"{aa1}{site}{aa2}")
-
-        if subs:
-            aaDiffs["substitutions"] = subs
-
-        if aaDiffs:
-            resultFeatures[name]["aa differences"] = aaDiffs
-
-        if not (orf["foundStartCodon"] and orf["foundStopCodon"]):
-            aend = alignmentEnd(
-                alignment.referenceAligned.sequence,
-                gappedOffset,
-                feature["stop"] - feature["start"],
-            )
-            resultFeatures[name]["debug"] = {
-                "genome orf": orf,
-                "feature alignment": {
-                    "reference": alignment.referenceAligned.sequence[gappedOffset:aend],
-                    "genome": alignment.genomeAligned.sequence[gappedOffset:aend],
-                },
-                "reference feature": feature.copy(),
-            }
-
-        if args.reportDifferences:
-            if not orf["foundStartCodon"]:
-                print(
-                    f"No START codon found for genome feature " f"{feature['name']!r}.",
-                    file=sys.stderr,
-                )
-
-            if not orf["foundStopCodon"]:
-                print(
-                    f"No STOP  codon found for genome feature " f"{feature['name']!r}.",
-                    file=sys.stderr,
-                )
-
-    # Sanity check that the Features class can load what we just produced.
-    Features(result, sars2=args.sars2)
-    print(dumps(result, sort_keys=True, indent=4))
-
-    if args.summarize:
-        print(f'Summary of changes for {result["id"]!r}', file=sys.stderr)
-        count = 0
-        for name, info in result["features"].items():
-            try:
-                aaDiffs = info["aa differences"]["substitutions"]
-            except KeyError:
-                aaDiff = "-"
-            else:
-                aaDiff = ", ".join(aaDiffs)
-
-            try:
-                n = info["aa differences"]["lengths"]["difference"]
-            except KeyError:
-                lenDiff = "-"
-            else:
-                lenDiff = f"{abs(n)} aa " + ("shorter" if n < 0 else "longer")
-
-            if not (aaDiff == lenDiff == "-"):
-                count += 1
-                print(
-                    "\t".join(
-                        (str(count), name, aaDiff, lenDiff, info.get("note", ""))
-                    ),
-                    file=sys.stderr,
-                )
-
-    return 0
+        return 0
 
 
-if __name__ == "__main__":
+def makeParser() -> argparse.ArgumentParser:
+    """
+    Make the command-line parser.
 
+    @return: An C{argparse.ArgumentParser}.
+    """
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         description="Print JSON annotations for a genome (or genomes).",
@@ -178,18 +63,11 @@ if __name__ == "__main__":
         help="Write a summary of differences to standard error.",
     )
 
-    parser.add_argument(
-        "--reportDifferences",
-        action="store_true",
-        help=(
-            "If the genome ORF differs from the reference due to no start or stop "
-            "codon, print a message."
-        ),
-    )
-
     addAlignerOption(parser)
     addFeatureOptions(parser)
 
-    args = parser.parse_args()
+    return parser
 
-    sys.exit(main(args))
+
+if __name__ == "__main__":
+    sys.exit(main(makeParser().parse_args()))

--- a/bin/describe-genome.py
+++ b/bin/describe-genome.py
@@ -14,7 +14,7 @@ from dark.dna import compareDNAReads, matchToString as dnaMatchToString
 from dark.reads import Read, Reads
 
 from sars2seq.alignment import SARS2Alignment, addAlignerOption
-from sars2seq.features import Features
+from sars2seq.features import Features, addFeatureOptions
 from sars2seq.translate import TranslationError
 from sars2seq.variants import VARIANTS
 
@@ -248,7 +248,7 @@ def processFeature(featureName, genome, fps, featureNumber, args):
 
 def main(args):
     """
-    Describe a SARS-CoV-2 genome.
+    Describe a genome or genomes.
 
     @param args: A C{Namespace} instance as returned by argparse with
         values for command-line options.
@@ -259,7 +259,11 @@ def main(args):
         if not exists(outDir):
             os.makedirs(outDir)
 
-    features = Features(args.gbFile)
+    features = Features(
+        args.reference,
+        sars2=args.sars2,
+        addUnannotatedRegions=args.addUnannotatedRegions,
+    )
 
     if args.feature:
         if args.canonicalNames:
@@ -325,7 +329,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-        description="Describe a SARS-CoV-2 genome (or genomes).",
+        description="Describe a genome (or genomes).",
     )
 
     parser.add_argument(
@@ -433,13 +437,6 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--gbFile",
-        metavar="file.gb",
-        default=Features.REF_GB,
-        help="The GenBank file to read for SARS-CoV-2 features.",
-    )
-
-    parser.add_argument(
         "--minReferenceCoverage",
         metavar="coverage",
         type=float,
@@ -464,6 +461,7 @@ if __name__ == "__main__":
         ),
     )
 
+    addFeatureOptions(parser)
     addAlignerOption(parser)
 
     args = parser.parse_args()

--- a/bin/describe-site.py
+++ b/bin/describe-site.py
@@ -9,7 +9,7 @@ from dark.fasta import FastaReads
 
 from sars2seq import Sars2SeqError
 from sars2seq.alignment import SARS2Alignment, addAlignerOption
-from sars2seq.features import Features
+from sars2seq.features import Features, addFeatureOptions
 
 
 def report(genome, args, includeGenome=True):
@@ -73,7 +73,11 @@ def main(args):
         values for command-line options.
     @return: An C{int} exit status.
     """
-    features = Features(args.gbFile)
+    features = Features(
+        args.reference,
+        sars2=args.sars2,
+        addUnannotatedRegions=args.addUnannotatedRegions,
+    )
     count = 0
 
     if args.genome is None and os.isatty(0):
@@ -181,13 +185,7 @@ if __name__ == "__main__":
         ),
     )
 
-    parser.add_argument(
-        "--gbFile",
-        metavar="file.gb",
-        default=Features.REF_GB,
-        help="The GenBank file to read for SARS-CoV-2 features.",
-    )
-
+    addFeatureOptions(parser)
     addAlignerOption(parser)
 
     args = parser.parse_args()

--- a/sars2seq/alignment.py
+++ b/sars2seq/alignment.py
@@ -755,7 +755,7 @@ class SARS2Alignment:
         if relativeToFeature:
             if featureName is None:
                 raise ValueError(
-                    "If relativeToFeature is True, a feature " "name must be given."
+                    "If relativeToFeature is True, a feature name must be given."
                 )
             referenceOffset = self.features.referenceOffset(featureName, offset, aa)
         else:

--- a/sars2seq/alignment.py
+++ b/sars2seq/alignment.py
@@ -35,7 +35,7 @@ class AlignmentError(Sars2SeqError):
     "There is an unexpected problem in the alignment."
 
 
-def addAlignerOption(parser: argparse.Namespace) -> None:
+def addAlignerOption(parser: argparse.ArgumentParser) -> None:
     """
     Add a command line option for specifying an aligner for SARS2Alignment.
 
@@ -480,7 +480,7 @@ class SARS2Alignment:
         base: str,
         offset: int,
         read: DNARead,
-        change: str,
+        change: Union[str, Tuple[Optional[str], int, Optional[str]]],
         featureName: str,
         onError,
         errFp,
@@ -533,7 +533,14 @@ class SARS2Alignment:
         aa: bool = False,
         onError: str = "raise",
         errFp: Optional[TextIO] = None,
-    ) -> Tuple[int, int, Dict[str, Tuple[bool, Optional[str], bool, Optional[str]]]]:
+    ) -> Tuple[
+        int,
+        int,
+        Dict[
+            Union[str, Tuple[str, int, str]],
+            Tuple[bool, Optional[str], bool, Optional[str]],
+        ],
+    ]:
         """Check that a set of changes all happened as expected.
 
         @param featureName: A C{str} feature name.
@@ -571,8 +578,8 @@ class SARS2Alignment:
         """
 
         def _getChanges(
-            changes: Union[str, Tuple[str, int, str]]
-        ) -> Iterator[Tuple[bool, Optional[str], bool, Optional[str]]]:
+            changes: Union[str, Iterable[Tuple[str, int, str]]]
+        ) -> Iterator[Tuple[Union[str, Tuple[str, int, str]], str, int, str]]:
             if isinstance(changes, str):
                 for change in changes.split():
                     referenceBase, offset, genomeBase = splitChange(change)
@@ -582,7 +589,9 @@ class SARS2Alignment:
                     referenceBase, offset, genomeBase = change
                     yield change, referenceBase, offset, genomeBase
 
-        result = {}
+        result: Dict[
+            Union[str, Tuple[Optional[str], int, Optional[str]]],
+        ] = {}
         testCount = errorCount = 0
 
         try:
@@ -718,7 +727,7 @@ class SARS2Alignment:
         featureName: Optional[str] = None,
         includeUntranslated: bool = False,
         minReferenceCoverage: Optional[float] = None,
-    ) -> dict:
+    ) -> Union[dict, None]:
         """
         Get information about genome features at an offset.
 

--- a/sars2seq/annotate.py
+++ b/sars2seq/annotate.py
@@ -1,0 +1,154 @@
+from operator import itemgetter
+from typing import Dict, List, Union
+
+from dark.reads import DNARead
+
+from sars2seq.alignment import SARS2Alignment, alignmentEnd
+from sars2seq.features import Features
+
+
+def annotateGenome(features: Features, genome: DNARead, aligner: str) -> dict:
+    """
+    Find features in an unannotated genome.
+
+    @param features: A C{Features} instance, with the features from
+        a sequence that is annotated.
+    @param genome: The C{DNARead} of the genome to annotate.
+    @aligner: A C{str} aligner name, such as 'edlib' or 'mafft'.
+    @raise ValueError: If the result we plan to return cannot be used to
+        initialize a new C{Features} instance.
+    @return: A C{dict} with C{str} feature names as keys. See the 'result'
+        variable below.
+    """
+    alignment = SARS2Alignment(genome, features, aligner=aligner)
+
+    result = {
+        "id": genome.id,
+        "sequence": genome.sequence,
+        "features": {},
+    }
+
+    resultFeatures = result["features"]
+
+    for feature in sorted(features.values(), key=itemgetter("start")):
+        name = feature["name"]
+        forward = feature["forward"]
+        gappedOffset = alignment.gappedOffsets[feature["start"]]
+
+        referenceAA, genomeAA = alignment.aaSequences(name, raiseOnReferenceGaps=False)
+
+        start = gappedOffset - alignment.genomeAligned.sequence[:gappedOffset].count(
+            "-"
+        )
+
+        if forward:
+            assert 0 <= start < len(genome)
+            orf = genome.findORF(start, forward=True, requireStartCodon=False)
+        else:
+            reverseGappedOffset = alignment.gappedOffsets[feature["stop"]]
+            reverseStart = (
+                len(alignment.genomeAligned)
+                - reverseGappedOffset
+                - alignment.genomeAligned.sequence[reverseGappedOffset:].count("-")
+            )
+            assert 0 <= reverseStart < len(genome)
+            orf = genome.findORF(reverseStart, forward=False, requireStartCodon=False)
+
+        # Small sanity check.
+        if not orf["foundStartCodon"]:
+            assert genomeAA.sequence[0] != "M"
+
+        stop = start + orf["length"] * 3
+
+        resultFeatures[name] = feature.copy()
+        resultFeatures[name].update(
+            {
+                "start": start,
+                "stop": stop,
+                "sequence": genome.sequence[start:stop],
+                "translation": orf["translation"],
+            }
+        )
+
+        aaDiffs: Dict[str, Union[dict, List[str]]] = {}
+
+        if len(orf["translation"]) != len(referenceAA):
+            aaDiffs["lengths"] = {
+                "genome length": len(orf["translation"]),
+                "reference length": len(referenceAA),
+                "difference": len(orf["translation"]) - len(referenceAA),
+            }
+
+        subs = []
+        # Note the the following zip deliberately stops at the shortest AA
+        # sequence.
+        for site, (aa1, aa2) in enumerate(
+            zip(referenceAA.sequence, orf["translation"]), start=1
+        ):
+            if aa1 != aa2:
+                subs.append(f"{aa1}{site}{aa2}")
+
+        if subs:
+            aaDiffs["substitutions"] = subs
+
+        if aaDiffs:
+            resultFeatures[name]["aa differences"] = aaDiffs
+
+        if not (orf["foundStartCodon"] and orf["foundStopCodon"]):
+            aend = alignmentEnd(
+                alignment.referenceAligned.sequence,
+                gappedOffset,
+                feature["stop"] - feature["start"],
+            )
+            resultFeatures[name]["debug"] = {
+                "genome orf": orf,
+                "feature alignment": {
+                    "reference": alignment.referenceAligned.sequence[gappedOffset:aend],
+                    "genome": alignment.genomeAligned.sequence[gappedOffset:aend],
+                },
+                "reference feature": feature.copy(),
+            }
+
+    try:
+        # Sanity check that the Features class can load what we just produced.
+        Features(result, sars2=features.sars2)
+    except Exception as e:
+        raise ValueError(
+            f"Could not use the result to initialize a " f"fresh Features instance: {e}"
+        )
+
+    return result
+
+
+def summarizeDifferences(annotations: dict) -> None:
+    """
+    Summarize new annotations.
+
+    @param annotations: The C{dict} result of calling C{annotateGenome}.
+    @return: A C{str} summary of differences.
+    """
+    result = [f'Summary of changes for {annotations["id"]!r}']
+
+    count = 0
+    for name, info in annotations["features"].items():
+        try:
+            aaDiffs = info["aa differences"]["substitutions"]
+        except KeyError:
+            aaDiff = "-"
+        else:
+            aaDiff = ", ".join(aaDiffs)
+
+        try:
+            n = info["aa differences"]["lengths"]["difference"]
+        except KeyError:
+            lenDiff = "-"
+        else:
+            lenDiff = f"{abs(n)} aa " + ("shorter" if n < 0 else "longer")
+
+        if not (aaDiff == lenDiff == "-"):
+            count += 1
+            result.append(
+                "\t".join((str(count), name, aaDiff, lenDiff, info.get("note", "")))
+            )
+
+    return "\n".join(result)

--- a/sars2seq/features.py
+++ b/sars2seq/features.py
@@ -3,14 +3,19 @@ from os import environ
 import itertools
 from collections import UserDict
 from pathlib import Path
-from typing import Optional, Union
+from typing import Dict, Optional, Set, Union
+from warnings import warn
+import json
 
 from Bio import Entrez, SeqIO
+from Bio.SeqRecord import SeqRecord
 
 from dark.aa import STOP_CODONS
+from dark.genbank import GenomeRanges
 from dark.reads import DNARead
 
 from sars2seq import Sars2SeqError, DATA_DIR
+from sars2seq.sars2 import SARS_COV_2_ALIASES, SARS_COV_2_TRANSLATED
 
 # Set ENTREZ_EMAIL in your environment to have your requests to NCBI Entez
 # be accompanied by your address. If you don't do this you'll see warning
@@ -30,95 +35,6 @@ class AmbiguousFeatureError(Sars2SeqError):
     "More than one feature is referred to by an offset."
 
 
-# Provide convenient aliases for feature names. The alias is the key, the
-# canonical name (as found in the GenBank file) is the value.
-#
-# Alphanumeric feature aliases must have lower case keys. If not they will not
-# be detected (and the test suite will fail).
-#
-# At some point we might want to make it possible to pass a custom set of
-# aliases to the Features constructor.
-
-ALIASES = {
-    "2": "2'-O-ribose methyltransferase",
-    "3clpro": "3C-like proteinase",
-    "3utr": "3'UTR",
-    "5utr": "5'UTR",
-    "e": "envelope protein",
-    "endornase": "endoRNAse",
-    "envelope": "envelope protein",
-    "exon": "3'-to-5' exonuclease",
-    "exonuclease": "3'-to-5' exonuclease",
-    "leader": "leader protein",
-    "m": "membrane glycoprotein",
-    "membrane": "membrane glycoprotein",
-    "mpro": "3C-like proteinase",
-    "n": "nucleocapsid phosphoprotein",
-    "nsp1": "leader protein",
-    "nsp5": "3C-like proteinase",
-    "nsp12": "RNA-dependent RNA polymerase",
-    "nsp13": "helicase",
-    "nsp14": "3'-to-5' exonuclease",
-    "nsp15": "endoRNAse",
-    "orf4": "envelope protein",
-    "orf5": "membrane glycoprotein",
-    "orf1a": "ORF1a polyprotein",
-    "orf1ab": "ORF1ab polyprotein",
-    "orf3a": "ORF3a protein",
-    "orf6": "ORF6 protein",
-    "orf7a": "ORF7a protein",
-    "orf7b": "ORF7b",
-    "orf8": "ORF8 protein",
-    "orf9": "nucleocapsid phosphoprotein",
-    "orf10": "ORF10 protein",
-    "rdrp": "RNA-dependent RNA polymerase",
-    "s": "surface glycoprotein",
-    "sl1": "stem loop 1",
-    "sl2": "stem loop 2",
-    "sl3": "stem loop 3",
-    "sl4": "stem loop 4",
-    "sl5": "stem loop 5",
-    "s": "surface glycoprotein",
-    "spike": "surface glycoprotein",
-}
-
-# Name of translated features, with (case sensitive!) names matching those in
-# the GenBank file ../data/NC_045512.2.gb
-#
-# At some point we might want to make it possible to pass a custom set of
-# translated names to the Features constructor.
-
-TRANSLATED = {
-    "3'-to-5' exonuclease",  # nsp14
-    "3C-like proteinase",  # nsp5
-    "endoRNAse",  # nsp15
-    "envelope protein",  # ORF4
-    "helicase",  # nsp13
-    "leader protein",  # nsp1
-    "membrane glycoprotein",  # ORF5
-    "nsp2",
-    "nsp3",
-    "nsp4",
-    "nsp6",
-    "nsp7",
-    "nsp8",
-    "nsp9",
-    "nsp10",
-    "nsp11",
-    "nucleocapsid phosphoprotein",  # ORF9
-    "ORF1a polyprotein",
-    "ORF1ab polyprotein",
-    "ORF3a protein",
-    "ORF6 protein",
-    "ORF7a protein",
-    "ORF7b",
-    "ORF8 protein",
-    "ORF10 protein",
-    "RNA-dependent RNA polymerase",  # nsp12
-    "surface glycoprotein",
-}
-
-
 class Features(UserDict):
     """
     Manage sequence features from the information in C{gbFile}.
@@ -130,6 +46,8 @@ class Features(UserDict):
               must not be C{None}. Passing a C{dict} is provided for testing.
         * C{None}, in which case the default reference, NC_045512.2.gb, is
               loaded.
+    @param sars2: A C{bool} indicating whether we are dealing with SARS-CoV-2
+        features (in which case some defaults can be set).
     @param reference: A C{dark.reads.DNARead} instance if C{spec} is a C{dict},
         else C{None}.
     @raise ValueError: If a reference is passed with a string or Path
@@ -141,28 +59,86 @@ class Features(UserDict):
     REF_GB = DATA_DIR / "NC_045512.2.gb"
 
     def __init__(
-        self, spec: Union[str, Path] = None, reference: Optional[DNARead] = None
+        self,
+        spec: Union[str, Path] = None,
+        reference: Optional[DNARead] = None,
+        sars2: bool = True,
+        translated: Optional[Set[str]] = None,
+        aliases: Optional[Dict[str, str]] = None,
+        addUnannotatedRegions: bool = False,
     ) -> None:
         super().__init__()
-        spec = self.REF_GB if spec is None else spec
+        self.sars2 = sars2
 
-        if isinstance(spec, str):
+        if sars2:
+            spec = self.REF_GB if spec is None else spec
+        else:
+            if spec is None:
+                raise ValueError(
+                    "A specification must be provided for non-SARS-CoV-2 features."
+                )
+
+        if isinstance(spec, SeqRecord):
+            record = spec
+            self._initializeFromGenBankRecord(record)
+        elif isinstance(spec, str):
             if reference is not None:
                 raise ValueError(
                     "A reference cannot be passed with a string specification."
                 )
             path = Path(spec)
             if path.exists():
+                # A file argument can either be in GenBank format or
+                # contain a JSON object (the saved output of annotate-genome.py).
+                jsonError = seqError = None
                 with open(path) as fp:
-                    record = SeqIO.read(fp, "genbank")
+                    try:
+                        record = json.load(fp)
+                    except json.decoder.JSONDecodeError as e:
+                        jsonError = e
+                    else:
+                        self.data.update(record["features"])
+                        self.reference = DNARead(record["id"], record["sequence"])
+
+                if jsonError:
+                    with open(path) as fp:
+                        try:
+                            record = SeqIO.read(fp, "genbank")
+                        except Exception as e:
+                            seqError = e
+                        else:
+                            self._initializeFromGenBankRecord(record)
+
+                if jsonError and seqError:
+                    print(
+                        f"Could not read {spec!r} as a JSON or GenBank file. "
+                        f"Here are the parsing errors.\nJSON: "
+                        f"{jsonError}\nGenBank: {seqError}",
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
             else:
                 print(f"Fetching GenBank record for {spec!r}.", file=sys.stderr)
-                client = Entrez.efetch(
-                    db="nucleotide", rettype="gb", retmode="text", id=spec
-                )
-                record = SeqIO.read(client, "gb")
-                client.close()
-            self._initializeFromGenBankRecord(record)
+                try:
+                    client = Entrez.efetch(
+                        db="nucleotide", rettype="gb", retmode="text", id=spec
+                    )
+                    try:
+                        record = SeqIO.read(client, "gb")
+                    except Exception as e:
+                        print(
+                            "Could not parse fetched GenBank record:",
+                            e,
+                            file=sys.stderr,
+                        )
+                        sys.exit(1)
+                    else:
+                        self._initializeFromGenBankRecord(record)
+                    finally:
+                        client.close()
+                except Exception as e:
+                    print("Could not fetch GenBank record:", e, file=sys.stderr)
+                    sys.exit(1)
         elif isinstance(spec, Path):
             if reference is not None:
                 raise ValueError(
@@ -172,10 +148,22 @@ class Features(UserDict):
                 record = SeqIO.read(fp, "genbank")
             self._initializeFromGenBankRecord(record)
         elif isinstance(spec, dict):
-            self.update(spec)
+            self.data.update(spec)
             self.reference: Optional[DNARead] = reference
         else:
             raise ValueError(f"Unrecognized specification {spec!r}.")
+
+        if sars2:
+            self.translatedNames = (
+                SARS_COV_2_TRANSLATED if translated is None else translated
+            )
+            self.aliasDict = SARS_COV_2_ALIASES if aliases is None else aliases
+        else:
+            self.translatedNames = translated
+            self.aliasDict = {} if aliases is None else aliases
+
+        if addUnannotatedRegions:
+            self._addUnannotatedRegions()
 
     def _initializeFromGenBankRecord(self, record: SeqIO.SeqRecord) -> None:
         """
@@ -189,8 +177,6 @@ class Features(UserDict):
 
         for feature in record.features:
             type_ = feature.type
-            start = int(feature.location.start)
-            stop = int(feature.location.end)
             value = {}
 
             if type_ == "3'UTR" or type_ == "5'UTR":
@@ -207,16 +193,41 @@ class Features(UserDict):
                 name = feature.qualifiers["product"][0]
                 value["product"] = name
 
-            elif type_ in {"source", "gene"}:
+            elif type_ in {"source", "gap", "gene", "repeat_region", "misc_feature"}:
+                assert "product" not in feature.qualifiers
                 continue
 
             else:
                 raise ValueError(f"Unknown feature type {type_!r}.")
 
+            start = int(feature.location.start)
+            stop = int(feature.location.end)
+            genomeRanges = GenomeRanges(str(feature.location))
+
+            # We can only handle a single range at the moment.
+            if len(genomeRanges.ranges) == 1:
+                assert start == genomeRanges.ranges[0][0]
+                assert stop == genomeRanges.ranges[0][1]
+                forward = genomeRanges.ranges[0][2]
+            elif self.sars2 and name == "ORF1ab polyprotein":
+                assert len(genomeRanges.ranges) == 2
+                assert start == genomeRanges.ranges[0][0]
+                assert stop == genomeRanges.ranges[1][1]
+                forward = True
+            else:
+                if not self.sars2:
+                    warn(
+                        f"Multiple reference genome ranges {genomeRanges} found "
+                        f"for feature {name!r} will not be translated reliably"
+                    )
+
+            sequence = str(record.seq)[start:stop]
+
             value.update(
                 {
+                    "forward": forward,
                     "name": name,
-                    "sequence": str(record.seq)[start:stop],
+                    "sequence": sequence,
                     "start": start,
                     "stop": stop,
                 }
@@ -236,20 +247,95 @@ class Features(UserDict):
             except KeyError:
                 pass
             else:
-                if (
-                    not translation.endswith("*")
-                    and value["sequence"][-3:].upper() in STOP_CODONS
-                ):
-                    value["translation"] += "*"
+                if not translation.endswith("*"):
+                    if forward:
+                        codon = value["sequence"][-3:]
+                    else:
+                        codon = (
+                            DNARead("id", sequence).reverseComplement().sequence[-3:]
+                        )
+                    if codon.upper() in STOP_CODONS:
+                        value["translation"] += "*"
 
-            if name in self:
-                assert self[name] == value
+            # The following elaborate dance makes sure that we use a name
+            # for the feature that is unique, including when case is
+            # ignored.  This makes it possible to use the feature names in
+            # self as file names even on a case-insensitive filesystem.
+            # Otherwise you will certainly end up with a mess, due to
+            # genome annotations that have multiple features with identical
+            # names (e.g., "hypothetical protein" several times, along with
+            # "Hypothetical protein").  E.g., download the GenBank file for
+            # NC_003310.1 (https://www.ncbi.nlm.nih.gov/nuccore/NC_003310.1/)
+            # and run this:
+            #
+            # $ grep product NC_003310.1.gb | grep -i hypothetical
+            existingName = self.getKeyIgnoringCase(name)
+            if existingName:
+                if self[existingName] != value:
+                    lowercaseNames = set(map(str.lower, self))
+                    for n in itertools.count(2):
+                        adjustedName = f"{name} {n}"
+                        if adjustedName.lower() not in lowercaseNames:
+                            name = adjustedName
+                            value["name"] = adjustedName
+                            self[name] = value
+                            break
             else:
                 self[name] = value
 
         self._checkForGaps()
 
-    def __getitem__(self, name: str) -> dict:
+    def _addUnannotatedRegions(self) -> None:
+        """
+        Find unannotated regions and add them as features.
+        """
+        annotatedOffsets = set()
+        for feature in self.data.values():
+            annotatedOffsets.update(range(feature["start"], feature["stop"]))
+            feature["annotated"] = True
+
+        start = None
+        unannotatedRegionCount = 0
+
+        def _addNew(stop):
+            nonlocal unannotatedRegionCount
+            unannotatedRegionCount += 1
+            name = f"unannotated region {unannotatedRegionCount}"
+            assert name not in self.data
+            self.data[name] = {
+                "name": name,
+                "annotated": False,
+                "start": start,
+                "stop": offset,
+                "sequence": self.reference.sequence[start:stop],
+            }
+
+        for offset in range(len(self.reference)):
+            if offset in annotatedOffsets:
+                if start is not None:
+                    _addNew(offset)
+                    start = None
+            else:
+                if start is None:
+                    start = offset
+
+        if start is not None:
+            _addNew(offset)
+
+    def getKeyIgnoringCase(self, name: str) -> Union[str, None]:
+        """
+        Find a key in self.data, ignoring case.
+
+        @param name: A C{str} name to look up.
+        @return: An existing C{str} key that matches C{name} when case is
+            ignored, or C{None} if no such key exists.
+        """
+        name = name.lower()
+        for thisName in self.data:
+            if thisName.lower() == name:
+                return thisName
+
+    def __getitem__(self, name: str) -> Union[dict, None]:
         """
         Find a feature by name. This produces a dictionary with the following
         keys and values for the feature:
@@ -299,12 +385,23 @@ class Features(UserDict):
             if nameLower == featureName.lower():
                 return featureName
 
-        alias = ALIASES.get(nameLower)
+        alias = self.aliasDict.get(nameLower)
         if alias is None:
             raise KeyError(name)
         else:
             assert alias in self
             return alias
+
+    def translated(self, name: str) -> bool:
+        """
+        Is a feature translated.
+
+        @param name: A C{str} feature name.
+        @return: A C{bool} to indicate whether the feature is translated.
+        """
+        return (self.translatedNames and name in self.translatedNames) or (
+            self.translatedNames is None and not self.sars2
+        )
 
     def aliases(self, name: str) -> set:
         """
@@ -313,10 +410,14 @@ class Features(UserDict):
         @param name: A C{str} feature name.
         @return: A C{set} of C{str} canonical names.
         """
-        canonicalName = self.canonicalName(name)
+        try:
+            canonicalName = self.canonicalName(name)
+        except KeyError:
+            return set()
+
         result = {canonicalName}
 
-        for alias, canonical in ALIASES.items():
+        for alias, canonical in self.aliasDict.items():
             if canonical == canonicalName:
                 result.add(alias)
 
@@ -369,7 +470,7 @@ class Features(UserDict):
 
         for name, feature in self.items():
             if feature["start"] <= offset < feature["stop"] and (
-                name in TRANSLATED or includeUntranslated
+                includeUntranslated or self.translated(name)
             ):
                 result.add(name)
 
@@ -409,7 +510,10 @@ class Features(UserDict):
                     featureName = list(features)[0]
                     feature = self[featureName]
                 else:
-                    present = ", ".join(f"{f!r}" for f in sorted(features))
+                    present = ", ".join(
+                        f"{f!r} ({self[f]['start'] + 1} - {self[f]['stop']})"
+                        for f in sorted(features)
+                    )
                     raise AmbiguousFeatureError(
                         f"There are multiple features at site {offset + 1}: "
                         f"{present}. Pass a feature name to specify which "
@@ -423,7 +527,10 @@ class Features(UserDict):
             feature = self[canonicalName]
             if canonicalName not in features:
                 if features:
-                    present = ", ".join(f"{f!r}" for f in sorted(features))
+                    present = ", ".join(
+                        f"{f!r} ({self[f]['start'] + 1} - {self[f]['stop']})"
+                        for f in sorted(features)
+                    )
                     raise MissingFeatureError(
                         f"Requested feature {featureName!r} (located at sites "
                         f'{feature["start"] + 1}-{feature["stop"]}) does not '
@@ -439,3 +546,117 @@ class Features(UserDict):
                     )
 
         return feature, features
+
+    def toString(
+        self, name: str, maxSequenceLength: int = 80, oneBased: bool = True
+    ) -> str:
+        """
+        Get a string representation of a feature suitable for printing.
+
+        @param name: A C{str} feature name.
+        @param maxSequenceLength: The C{int} maximum sequence (prefix) length to
+            include. Pass -1 to specify the full sequence or 0 to exclude sequences
+            from the result.
+        @param oneBased: A C{bool}. If C{True} the feature location should be printed
+            1-based instead of 0-based.
+        @return: A C{str}.
+        """
+        canonicalName = self.canonicalName(name)
+        feature = self[canonicalName]
+        result = [
+            f"{name}:",
+            f"  start: {feature['start'] + bool(oneBased)}",
+            f"  stop: {feature['stop']}",
+            f"  length: {feature['stop'] - feature['start']}",
+        ]
+
+        for name in "product", "note", "function":
+            try:
+                result.append(f"  {name}: {feature[name]}")
+            except KeyError:
+                pass
+
+        if maxSequenceLength:
+            sequence = feature["sequence"]
+            result.append(
+                f"  sequence    (len {len(sequence):5d} nt): "
+                + (
+                    (sequence[:maxSequenceLength] + "...")
+                    if maxSequenceLength > 0 and len(sequence) > maxSequenceLength
+                    else sequence
+                )
+            )
+
+            # Use True as a default for 'forward' in the following, as some
+            # features may be unannotated region, and these do not have a
+            # 'forward' key. Using True as the default means we will not
+            # uselessly reverse complement an unannotated region.
+            if "forward" in feature:
+                if feature["forward"]:
+                    result.append("  feature is translated left-to-right.")
+                else:
+                    result.append(
+                        "  feature is translated right-to-left from the "
+                        "reverse complement."
+                    )
+                    rc = DNARead("id", sequence).reverseComplement().sequence
+                    result.append(
+                        f"  reverse complement (len {len(sequence):5d} nt): "
+                        + (
+                            (rc[:maxSequenceLength] + "...")
+                            if maxSequenceLength > 0 and len(rc) > maxSequenceLength
+                            else rc
+                        )
+                    )
+            else:
+                result.append("  region is unannotated.")
+
+        if maxSequenceLength:
+            try:
+                translation = feature["translation"]
+            except KeyError:
+                # Some features (e.g., UTR, stem loops) do not have a translation.
+                pass
+            else:
+                result.append(
+                    f"  translation (len {len(translation):5d} aa): "
+                    + (
+                        (translation[:maxSequenceLength] + "...")
+                        if maxSequenceLength > 0
+                        and len(translation) > maxSequenceLength
+                        else translation
+                    )
+                )
+
+        return "\n".join(result)
+
+
+def addFeatureOptions(parser) -> None:
+    """
+    Add standard command-line options that can then be passed to the Feature constructor.
+
+    @args parser: An argparse parser to add options to.
+    """
+    parser.add_argument(
+        "--reference",
+        "--gbFile",  # The name originally used. Kept for backwards compatibility.
+        metavar="file.gb",
+        default=Features.REF_GB,
+        help="The GenBank file to read for features and sequences.",
+    )
+
+    parser.add_argument(
+        "--sars2",
+        action="store_true",
+        help="The sequence is from a SARS-CoV-2 virus.",
+    )
+
+    parser.add_argument(
+        "--addUnannotatedRegions",
+        action="store_true",
+        help=(
+            "Also add unannotated regions (i.e., genome regions that have "
+            'no features). These will be named "unannotated region 1", '
+            '"unannotated region 2", and so on, as needed.'
+        ),
+    )

--- a/sars2seq/features.py
+++ b/sars2seq/features.py
@@ -149,7 +149,7 @@ class Features(UserDict):
         if isinstance(spec, str):
             if reference is not None:
                 raise ValueError(
-                    "A reference cannot be passed with a string " "specification."
+                    "A reference cannot be passed with a string specification."
                 )
             path = Path(spec)
             if path.exists():
@@ -166,7 +166,7 @@ class Features(UserDict):
         elif isinstance(spec, Path):
             if reference is not None:
                 raise ValueError(
-                    "A reference cannot be passed with a Path " "specification."
+                    "A reference cannot be passed with a Path specification."
                 )
             with open(spec) as fp:
                 record = SeqIO.read(fp, "genbank")

--- a/sars2seq/features.py
+++ b/sars2seq/features.py
@@ -4,7 +4,8 @@ import itertools
 from collections import UserDict
 from pathlib import Path
 from typing import Dict, Optional, Set, Union
-from warnings import warn
+
+# from warnings import warn
 import json
 import argparse
 
@@ -70,6 +71,7 @@ class Features(UserDict):
     ) -> None:
         super().__init__()
         self.sars2 = sars2
+        self.translatedNames: Optional[Set[str]] = None
 
         if sars2:
             spec = self.REF_GB if spec is None else spec

--- a/sars2seq/sars2.py
+++ b/sars2seq/sars2.py
@@ -1,0 +1,81 @@
+# Provide convenient aliases for SARS-CoV-2 feature names. The alias is the
+# key, the canonical name (as found in the GenBank file) is the value.
+#
+# Alphanumeric feature aliases must have lower case keys. If not they will not
+# be detected (and the test suite will fail).
+
+SARS_COV_2_ALIASES = {
+    "2": "2'-O-ribose methyltransferase",
+    "3clpro": "3C-like proteinase",
+    "3utr": "3'UTR",
+    "5utr": "5'UTR",
+    "e": "envelope protein",
+    "endornase": "endoRNAse",
+    "envelope": "envelope protein",
+    "exon": "3'-to-5' exonuclease",
+    "exonuclease": "3'-to-5' exonuclease",
+    "leader": "leader protein",
+    "m": "membrane glycoprotein",
+    "membrane": "membrane glycoprotein",
+    "mpro": "3C-like proteinase",
+    "n": "nucleocapsid phosphoprotein",
+    "nsp1": "leader protein",
+    "nsp5": "3C-like proteinase",
+    "nsp12": "RNA-dependent RNA polymerase",
+    "nsp13": "helicase",
+    "nsp14": "3'-to-5' exonuclease",
+    "nsp15": "endoRNAse",
+    "orf4": "envelope protein",
+    "orf5": "membrane glycoprotein",
+    "orf1a": "ORF1a polyprotein",
+    "orf1ab": "ORF1ab polyprotein",
+    "orf3a": "ORF3a protein",
+    "orf6": "ORF6 protein",
+    "orf7a": "ORF7a protein",
+    "orf7b": "ORF7b",
+    "orf8": "ORF8 protein",
+    "orf9": "nucleocapsid phosphoprotein",
+    "orf10": "ORF10 protein",
+    "rdrp": "RNA-dependent RNA polymerase",
+    "s": "surface glycoprotein",
+    "sl1": "stem loop 1",
+    "sl2": "stem loop 2",
+    "sl3": "stem loop 3",
+    "sl4": "stem loop 4",
+    "sl5": "stem loop 5",
+    "s": "surface glycoprotein",
+    "spike": "surface glycoprotein",
+}
+
+# Name of translated features, with (case sensitive!) names matching those in
+# the GenBank file ../data/NC_045512.2.gb
+
+SARS_COV_2_TRANSLATED = {
+    "3'-to-5' exonuclease",  # nsp14
+    "3C-like proteinase",  # nsp5
+    "endoRNAse",  # nsp15
+    "envelope protein",  # ORF4
+    "helicase",  # nsp13
+    "leader protein",  # nsp1
+    "membrane glycoprotein",  # ORF5
+    "nsp2",
+    "nsp3",
+    "nsp4",
+    "nsp6",
+    "nsp7",
+    "nsp8",
+    "nsp9",
+    "nsp10",
+    "nsp11",
+    "nucleocapsid phosphoprotein",  # ORF9
+    "ORF1a polyprotein",
+    "ORF1ab polyprotein",
+    "ORF3a protein",
+    "ORF6 protein",
+    "ORF7a protein",
+    "ORF7b",
+    "ORF8 protein",
+    "ORF10 protein",
+    "RNA-dependent RNA polymerase",  # nsp12
+    "surface glycoprotein",
+}

--- a/sars2seq/translate.py
+++ b/sars2seq/translate.py
@@ -96,7 +96,7 @@ def translate(seq: str, name: Optional[str] = None) -> str:
     remainder = len(seq) % 3
     seq += "N" * (3 - remainder if remainder else 0)
 
-    return Seq(seq).translate()
+    return str(Seq(seq).translate())
 
 
 def translateSpike(seq: str) -> str:

--- a/sars2seq/variants.py
+++ b/sars2seq/variants.py
@@ -17,7 +17,7 @@ VARIANTS = {
     },
     "B117-typing": {
         "description": (
-            "UK variant, based on just two tests (as in " "typing-PCR assays."
+            "UK variant, based on just two tests (as in typing-PCR assays)."
         ),
         "changes": {
             "spike": {

--- a/test/test_alignment.py
+++ b/test/test_alignment.py
@@ -658,7 +658,7 @@ class TestOffsetInfo(TestCase):
         error = (
             r"^Requested feature 'surface glycoprotein' \(located at "
             r"sites 1-6\) does not overlap site 11. The feature\(s\) "
-            r"at that site are: 'nsp10'\.$"
+            r"at that site are: 'nsp10' \(11 - 16\)\.$"
         )
         for relativeToFeature in False, True:
             self.assertRaisesRegex(
@@ -701,7 +701,7 @@ class TestOffsetInfo(TestCase):
         error = (
             r"^Requested feature 'surface glycoprotein' \(located at "
             r"sites 1-6\) does not overlap site 11. The feature\(s\) "
-            r"at that site are: 'nsp10', 'nsp11'\.$"
+            r"at that site are: 'nsp10' \(11 - 16\), 'nsp11' \(11 - 16\)\.$"
         )
         for relativeToFeature in False, True:
             self.assertRaisesRegex(
@@ -735,9 +735,8 @@ class TestOffsetInfo(TestCase):
         )
         alignment = SARS2Alignment(DNARead("genId", "AA"), features=features)
         error = (
-            r"^There are multiple features at site 13: 'nsp10', "
-            r"'nsp11'. Pass a feature name to specify which one you "
-            r"want\.$"
+            r"^There are multiple features at site 13: 'nsp10' \(11 - 16\), 'nsp11' "
+            r"\(11 - 16\). Pass a feature name to specify which one you want\.$"
         )
 
         self.assertRaisesRegex(AmbiguousFeatureError, error, alignment.offsetInfo, 12)

--- a/test/test_sars2.py
+++ b/test/test_sars2.py
@@ -1,0 +1,17 @@
+from unittest import TestCase
+
+from sars2seq.sars2 import SARS_COV_2_ALIASES
+
+
+class TestSars2Aliases(TestCase):
+    """
+    Test the SARS_COV_2_ALIASES dict.
+    """
+
+    def testAliasKeysLowerCase(self):
+        """
+        Alphanumeric alias keys must be lower case in order to be found.
+        """
+        self.assertTrue(
+            all(key.islower() for key in SARS_COV_2_ALIASES if key.isalpha())
+        )

--- a/test/test_translate.py
+++ b/test/test_translate.py
@@ -77,6 +77,13 @@ class TestTranslate(TestCase):
         """
         self.assertEqual("K", translate("AAA"))
 
+    def testAAAPlusStop(self):
+        """
+        An AAA codon followed by a stop codon must translate to a Lysine (K)
+        followed by a '*'.
+        """
+        self.assertEqual("K*", translate("AAATAG"))
+
     def testNameWithAAA(self):
         """
         An AAA codon must translate to a Lysine (K) when a name other than


### PR DESCRIPTION
Generalized to deal with non-SARS2 features. Added annotate-genome.py script. Handle translation of reverse-complemented ORFs. Allow passing names of translated features and also feature aliases. Make it possible to load features from a JSON file (as produced by annotate-genome.py).  Added checking for multiple genome ranges. Made it possible to treat unannotated genome regions as regular features.

Also, the code has been reformatted to use [black](https://black.readthedocs.io/en/stable/index.html)